### PR TITLE
Feature/custom shorten

### DIFF
--- a/classes/class-utmdotcodes.php
+++ b/classes/class-utmdotcodes.php
@@ -1746,6 +1746,14 @@ class UtmDotCodes {
             /**
              * Cuttly
              */
+            //connection error
+            case 4220:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( 'Unable to connect to cutt.ly API to shorten url. Please try again later.', 'utm-dot-codes' ),
+                ];
+                break;
+            // status codes
             case 4221:
                 $error_message = [
                     'style'   => 'notice-error',
@@ -1780,6 +1788,19 @@ class UtmDotCodes {
                 $error_message = [
                     'style'   => 'notice-error',
                     'message' => esc_html__( 'The link provided is from a blocked domain.', 'utm-dot-codes' ),
+                ];
+                break;
+            //
+            case 4227:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( 'cutt.ly API responded with unauthorized error. API Key is invalid or rate limit exceeded.', 'utm-dot-codes' ),
+                ];
+                break;
+            case 4228:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( 'cutt.ly API experienced an error when shortening the link, please try again later.', 'utm-dot-codes' ),
                 ];
                 break;
 		}

--- a/classes/class-utmdotcodes.php
+++ b/classes/class-utmdotcodes.php
@@ -1742,6 +1742,46 @@ class UtmDotCodes {
 					'message' => esc_html__( 'Rebrandly API experienced an error when shortening the link, please try again later.', 'utm-dot-codes' ),
 				];
 				break;
+
+            /**
+             * Cuttly
+             */
+            case 4221:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( 'The shortened link comes from the domain that shortens the link, i.e. the link has already been shortened.', 'utm-dot-codes' ),
+                ];
+                break;
+            case 4222:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( 'The entered link is not a link.', 'utm-dot-codes' ),
+                ];
+                break;
+            case 4223:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( 'The preferred link name is already taken.', 'utm-dot-codes' ),
+                ];
+                break;
+            case 4224:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( ' Invalid API key.', 'utm-dot-codes' ),
+                ];
+                break;
+            case 4225:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( 'the link has not passed the validation. Includes invalid characters.', 'utm-dot-codes' ),
+                ];
+                break;
+            case 4226:
+                $error_message = [
+                    'style'   => 'notice-error',
+                    'message' => esc_html__( 'The link provided is from a blocked domain.', 'utm-dot-codes' ),
+                ];
+                break;
 		}
 
 		return apply_filters( 'utmdc_error_message', $error_message, $error_code );

--- a/classes/shorten/class-cuttly.php
+++ b/classes/shorten/class-cuttly.php
@@ -13,7 +13,6 @@ namespace UtmDotCodes;
 class Cuttly implements \UtmDotCodes\Shorten {
 
 	const API_URL = 'https://cutt.ly/api/api.php';
-	const ERROR_CODE_UNIQUE_PREFIX = 'cuttly';
 
 	/**
 	 * API credentials for Cutt.ly API.
@@ -43,12 +42,6 @@ class Cuttly implements \UtmDotCodes\Shorten {
 	 */
 	public function __construct( $api_key ) {
 		$this->api_key = $api_key;
-        $this->add_custom_error_code_filter(1, 'the shortened link comes from the domain that shortens the link, i.e. the link has already been shortened');
-        $this->add_custom_error_code_filter(2, 'the entered link is not a link');
-        $this->add_custom_error_code_filter(3, 'the preferred link name is already taken');
-        $this->add_custom_error_code_filter(4, 'Invalid API key');
-        $this->add_custom_error_code_filter(5, 'the link has not passed the validation. Includes invalid characters');
-        $this->add_custom_error_code_filter(6, 'The link provided is from a blocked domain');
     }
 
 	/**
@@ -94,7 +87,7 @@ class Cuttly implements \UtmDotCodes\Shorten {
 				$response_code = intval( $response['response']['code'] );
 				if ( 200 === $response_code || 201 === $response_code ) {
 				    $urlData = $body['url'];
-				    $status = (int) $urlData['status'];
+				    $status = $urlData['status'];
 				    if ( $status === 7) {
 
 				        //if the status is 7 then the link has been shortened (according to API docs: https://cutt.ly/cuttly-api)
@@ -109,7 +102,7 @@ class Cuttly implements \UtmDotCodes\Shorten {
                         }
                     } else {
 				        //otherwise we handle the status codes according to the API docs: https://cutt.ly/cuttly-api
-                        $this->set_custom_error_code($status);
+                        $this->error_code = (int) ('422'.$status);
                     }
 				} elseif ( 403 === $response_code ) {
 					$this->error_code = 4030;
@@ -137,36 +130,4 @@ class Cuttly implements \UtmDotCodes\Shorten {
 	public function get_error() {
 		return $this->error_code;
 	}
-
-    /**
-     * sets the error code for a custom shortener error
-     * @param $error_code
-     */
-	private function set_custom_error_code($error_code) {
-	    $this->error_code = self::ERROR_CODE_UNIQUE_PREFIX . $error_code;
-
-	}
-
-    /**
-     * adds a filter for a custom shortener error code
-     * @param $custom_error_code
-     * @param $custom_error_message
-     * @param string $custom_error_class
-     */
-	private function add_custom_error_code_filter($custom_error_code, $custom_error_message, $custom_error_class = 'notice-info') {
-        add_filter(
-            'utmdc_error_message',
-            function( $error_message, $error_code ) use ($custom_error_code, $custom_error_message, $custom_error_class) {
-                if ( $custom_error_code . self::ERROR_CODE_UNIQUE_PREFIX === $error_code ) {
-                    $error_message = [
-                        'style'   => $custom_error_class,
-                        'message' => $custom_error_message,
-                    ];
-                }
-                return $error_message;
-            },
-            10,
-            2
-        );
-    }
 }

--- a/classes/shorten/class-cuttly.php
+++ b/classes/shorten/class-cuttly.php
@@ -81,7 +81,7 @@ class Cuttly implements \UtmDotCodes\Shorten {
 				]
 			);
 			if ( isset( $response->errors ) ) {
-				$this->error_code = 100;
+				$this->error_code = 4220;
 			} else {
 				$body = json_decode( $response['body'], true);
 				$response_code = intval( $response['response']['code'] );
@@ -105,9 +105,9 @@ class Cuttly implements \UtmDotCodes\Shorten {
                         $this->error_code = (int) ('422'.$status);
                     }
 				} elseif ( 403 === $response_code ) {
-					$this->error_code = 4030;
+					$this->error_code = 4227;
 				} else {
-					$this->error_code = 500;
+					$this->error_code = 4228;
 				}
 			}
 		}

--- a/classes/shorten/class-cuttly.php
+++ b/classes/shorten/class-cuttly.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Cuttly API shortener class.
+ *
+ * @package UtmDotCodes
+ */
+
+namespace UtmDotCodes;
+
+/**
+ * Class Cuttly.
+ */
+class Cuttly implements \UtmDotCodes\Shorten {
+
+	const API_URL = 'https://cutt.ly/api/api.php';
+
+	/**
+	 * API credentials for Cutt.ly API.
+	 *
+	 * @var string|null The API key for the shortener.
+	 */
+	private $api_key;
+
+	/**
+	 * Response from API.
+	 *
+	 * @var object|null The response object from the shortener.
+	 */
+	private $response;
+
+	/**
+	 * Error message.
+	 *
+	 * @var object|null Error object with code and message properties.
+	 */
+	private $error_code;
+
+	/**
+	 * Cuttly constructor.
+	 *
+	 * @param string $api_key Credentials for API.
+	 */
+	public function __construct( $api_key ) {
+		$this->api_key = $api_key;
+	}
+
+	/**
+	 * See interface for docblock.
+	 *
+	 * @inheritDoc
+	 *
+	 * @param array  $data See interface.
+	 * @param string $query_string See interface.
+	 *
+	 * @return void
+	 */
+	public function shorten( $data, $query_string ) {
+		if ( isset( $data['meta_input'] ) ) {
+			$data = $data['meta_input'];
+		}
+
+		if ( '' !== $this->api_key ) {
+		    //assemble the long url with the utm query string
+		    $link_to_shorten = $data['utmdclink_url'] . $query_string;
+		    //assemble the full url for the GET request to the API endpoint
+		    $fullQueryURL = self::API_URL . '?key=' . $this->api_key . '&short=' . $link_to_shorten . '&name=' . $data['utmdclink_shorturl'];
+			$response = wp_remote_get(
+				$fullQueryURL,
+				// Selective overrides of WP_Http() defaults.
+				[
+					'timeout'     => 15,
+					'redirection' => 5,
+					'httpversion' => '1.1',
+					'blocking'    => true,
+					'headers'     => [
+						'Content-Type'  => 'application/json',
+					],
+				]
+			);
+            var_dump($response, true);
+
+			if ( isset( $response->errors ) ) {
+				$this->error_code = 100;
+			} else {
+				$body = json_decode( $response['body'], true);
+				$response_code = intval( $response['response']['code'] );
+				if ( 200 === $response_code || 201 === $response_code ) {
+				    $urlData = $body['url'];
+				    $status = $urlData['status'];
+				    if ( 7 == $status) {
+                        $response_url = '';
+
+                        if ( isset( $body['shortLink'] ) ) {
+                            $response_url = $body['shortLink'];
+                        }
+
+                        if ( filter_var( $response_url, FILTER_VALIDATE_URL ) ) {
+                            $this->response = esc_url( wp_unslash( $body['shortLink'] ) );
+                        }
+                    } else {
+                        //handle error status codes
+                    }
+				} elseif ( 403 === $response_code ) {
+					$this->error_code = 4030;
+				} else {
+					$this->error_code = 500;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get response from Cutt.ly API for the request.
+	 *
+	 * @inheritDoc
+	 */
+	public function get_response() {
+		return $this->response;
+	}
+
+	/**
+	 * Get error code/message returned by Cutt.ly API for the request.
+	 *
+	 * @inheritDoc
+	 */
+	public function get_error() {
+		return $this->error_code;
+	}
+}


### PR DESCRIPTION
**My initial setup steps:**
- set up local wp vagrant box (http://vccw.cc/) and drop cloned utm.code repo into plugins directory
- set remote for locally cloned utm.code repo to my github account (bsmithdx/utm.codes)
- create a feature/customShorten branch to work on
- enable utm.code plugin in wordpress
- Create new Cuttly Class (based off of the Bitly implementation so I'd share common implementation)
- Add 'utmdc_shorten_object' filter to default theme's functions.php file to return my new Cuttly class

**Implementation Summary**
I started by looking at the utm.codes repo, specifically the Shorten Interface and the Bitly implementation that already existed. I didn't want to reinvent the wheel so I started with the Bitly implementation as a template since I figured there would be a lot of overlap with my Cuttly implementation. After registering with cutt.ly and getting an API key I changed the respective const and started modifying the shorten() method. I sent the API request using the wp_remote_get function assembling the api endpoint url by urlencoding and adding the "long link" and the utm params as one query param along with the api key as the other. I kept the structure of the error handling only adding the check for the "status" property in the resulting JSON from cutt.ly to be 7 for a success and an error for anything else (as specified in their api documentation). At this point I was able to get working api requests with successfully shortened urls. I then added error reporting. I wrote my own wrapper for a call to the custom error filter (utmdc_error_message) so that I could try and add the custom filters based on the cuttly status codes from my class constructor. At this point I ran into some issues as calling add_filters for he custom error filter from within my class wasn't working (probably due to a timing issue). I knew that I could add the filters for the errors from my theme's functions.php file, but I didn't want to have to include the whole wordpress project in my repo. At this point I decided to refactor and just add the error handling alongside the errors for the Bitly and Rebrandly implementations in the UtmDotCodes class itself. If I were implementing a custom shortener as part of a custom site I'd put them in the functions.php file, but since I'm extending the utm.codes plugin itself I figured this was cleaner.

**Testing Instructions**
The only thing I had to add to test my implementation was adding this add_filters call to the bottom of my theme's functions.php file:
```
add_filter('utmdc_shorten_object', function( $shortener ){
    include_once ABSPATH . 'wp-content/plugins/utm.codes/classes/shorten/class-cuttly.php';
    return new \UtmDotCodes\Cuttly( 'fde050cfeda860408a6f4e76849bf7c29b5ed' );
});
```

**Local Configuration**:
Vagrant Box: http://vccw.cc/
- **WordPress version**: 5.2.1
- **PHP version**: 7.0.26-2+ubuntu16.04.1+deb.sury.org+2
- **MySQL version**: 5.7.20-0ubuntu0.16.04.1 


